### PR TITLE
chore(dependencies): Remove check-type

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,41 +48,37 @@ module.exports =
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	
+
 	var _interopRequireDefault = __webpack_require__(2)['default'];
-	
+
 	var _through2 = __webpack_require__(3);
-	
+
 	var _through22 = _interopRequireDefault(_through2);
-	
+
 	var _path = __webpack_require__(4);
-	
+
 	var _path2 = _interopRequireDefault(_path);
-	
+
 	var _gulpUtil = __webpack_require__(5);
-	
+
 	var _gulpUtil2 = _interopRequireDefault(_gulpUtil);
-	
+
 	var _jsYaml = __webpack_require__(1);
-	
+
 	var _jsYaml2 = _interopRequireDefault(_jsYaml);
-	
+
 	var _extend = __webpack_require__(6);
-	
+
 	var _extend2 = _interopRequireDefault(_extend);
-	
+
 	var _bufferstreams = __webpack_require__(7);
-	
+
 	var _bufferstreams2 = _interopRequireDefault(_bufferstreams);
-	
+
 	var _jsYaml3 = _interopRequireDefault(_jsYaml);
-	
-	var _checkType = __webpack_require__(8);
-	
+
 	var PLUGIN_NAME = 'gulp-yaml-validate';
-	
-	var check = (0, _checkType.init)();
-	
+
 	var yaml2json = function yaml2json(buffer, options) {
 	  var htmlRe = /(<([^>]+)>)/ig;
 	  var contents = buffer.toString('utf8');
@@ -93,7 +89,7 @@ module.exports =
 	    return new Buffer(JSON.stringify(ymlDocument, options.replacer, options.space));
 	  }
 	};
-	
+
 	module.exports = function (options) {
 	  var options = (0, _extend2['default'])({
 	    safe: false,
@@ -101,7 +97,7 @@ module.exports =
 	    replacer: null,
 	    space: null
 	  }, options);
-	
+
 	  return _through22['default'].obj(function (file, enc, cb) {
 	    var self = this;
 	    if (file.isBuffer()) {
@@ -157,13 +153,13 @@ module.exports =
 /***/ function(module, exports, __webpack_require__) {
 
 	"use strict";
-	
+
 	exports["default"] = function (obj) {
 	  return obj && obj.__esModule ? obj : {
 	    "default": obj
 	  };
 	};
-	
+
 	exports.__esModule = true;
 
 /***/ },
@@ -195,12 +191,6 @@ module.exports =
 /***/ function(module, exports, __webpack_require__) {
 
 	module.exports = require("bufferstreams");
-
-/***/ },
-/* 8 */
-/***/ function(module, exports, __webpack_require__) {
-
-	module.exports = require("check-type");
 
 /***/ }
 /******/ ]);

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "bufferstreams": "^1.0.1",
-    "check-type": "^0.4.11",
     "extend": "^2.0.1",
     "gulp-util": "^3.0.5",
     "js-yaml": "^3.3.1",

--- a/task/index.js
+++ b/task/index.js
@@ -9,8 +9,6 @@ import BufferStreams from 'bufferstreams';
 const PLUGIN_NAME = 'gulp-yaml-validate';
 
 import yaml from 'js-yaml';
-import {init} from 'check-type';
-const check = init();
 
 const yaml2json = (buffer, options) => {
     const htmlRe = /(<([^>]+)>)/ig;


### PR DESCRIPTION
Removes `check-type` dependency because it contain a vulnerable version of `underscore` and also doesn't seem to be really used in the project